### PR TITLE
Update deprecated Cerebras default model (fixes #100)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@
 
 # Other Contributors
 ----------
+- [muhamedfazalps](https://github.com/muhamedfazalps)
 - [Gemini](https://gemini.google.com) ++
 
 ++ Graphic designer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Cerebras default model changed to `gpt-oss-120b`
 ## [0.8] - 2026-06-14
 ### Added
 - `MyTextError` class
@@ -15,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Instructions modified
 - AI Studio default model changed to `gemma-4-31b-it`
 - Cloudflare default model changed to `llama-3.1-8b-instruct-fast`
-- Cerebras default model changed to `gpt-oss-120b`
 - `README.md` updated
 - Test system modified
 - Dependencies structure modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Instructions modified
 - AI Studio default model changed to `gemma-4-31b-it`
 - Cloudflare default model changed to `llama-3.1-8b-instruct-fast`
+- Cerebras default model changed to `gpt-oss-120b`
 - `README.md` updated
 - Test system modified
 - Dependencies structure modified

--- a/mytext/params.py
+++ b/mytext/params.py
@@ -71,7 +71,7 @@ DEFAULT_MODELS = {
     Provider.AI_STUDIO: "gemma-4-31b-it",
     Provider.CLOUDFLARE: "meta/llama-3.1-8b-instruct-fast",
     Provider.OPENROUTER: "openai/gpt-oss-20b:free",
-    Provider.CEREBRAS: "llama3.1-8b",
+    Provider.CEREBRAS: "llama-3.3-70b",
     Provider.GROQ: "openai/gpt-oss-20b",
     Provider.NVIDIA: "meta/llama-3.1-8b-instruct",
     Provider.GITHUB: "openai/gpt-4o-mini",

--- a/mytext/params.py
+++ b/mytext/params.py
@@ -71,7 +71,7 @@ DEFAULT_MODELS = {
     Provider.AI_STUDIO: "gemma-4-31b-it",
     Provider.CLOUDFLARE: "meta/llama-3.1-8b-instruct-fast",
     Provider.OPENROUTER: "openai/gpt-oss-20b:free",
-    Provider.CEREBRAS: "llama-3.3-70b",
+    Provider.CEREBRAS: "gpt-oss-120b",
     Provider.GROQ: "openai/gpt-oss-20b",
     Provider.NVIDIA: "meta/llama-3.1-8b-instruct",
     Provider.GITHUB: "openai/gpt-4o-mini",


### PR DESCRIPTION
## Problem
Fixes #100

The default Cerebras model `llama3.1-8b` was deprecated on 2026-05-27 per [Cerebras deprecation notice](https://inference-docs.cerebras.ai/support/deprecation#2026-05-27). Running `run_mytext("Hi", provider=Provider.CEREBRAS)` now returns:

```
{'status': False, 'message': 'Model llama3.1-8b does not exist or you do not have access to it.'}
```

## Fix
Updated the default model in `mytext/params.py` from `llama3.1-8b` to `llama-3.3-70b`.

## Testing
- [x] Verified new model name matches Cerebras documentation
- [x] One-line change in `params.py`

---
If this fix helped, consider buying me a coffee! ☕
[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-ffdd00?style=flat&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/muhamedfazalps)