### PR TITLE
fix: update Cerebras default model from deprecated llama3.1-8b to gpt-oss-120b

### DIFF
--- a/mytext/params.py
+++ b/mytext/params.py
@@ -71,7 +71,7 @@ DEFAULT_MODELS = {
     Provider.AI_STUDIO: "gemma-4-31b-it",
     Provider.CLOUDFLARE: "meta/llama-3.1-8b-instruct-fast",
     Provider.OPENROUTER: "openai/gpt-oss-20b:free",
-    Provider.CEREBRAS: "llama3.1-8b",
+    Provider.CEREBRAS: "gpt-oss-120b",
     Provider.GROQ: "openai/gpt-oss-20b",
     Provider.NVIDIA: "meta/llama-3.1-8b-instruct",
     Provider.GITHUB: "openai/gpt-4o-mini",


### PR DESCRIPTION
## Problem

The Cerebras default model `llama3.1-8b` was deprecated on 2026-05-27 per [Cerebras documentation](https://inference-docs.cerebras.ai/support/deprecation#2026-05-27). Running `run_mytext()` with the Cerebras provider now returns:

```
{'status': False, 'message': 'Model llama3.1-8b does not exist or you do not have access to it.'}
```

## Fix

Updated the default model from `llama3.1-8b` to `gpt-oss-120b` as recommended by Cerebras.

Fixes #100

---

If this helps, consider buying me a coffee! https://buymeacoffee.com/muhamedfazalps