### PR TITLE
Nvidia default model updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Validation system modified
 - `README.md` updated
 - OpenRouter default model changed to `z-ai/glm-5.2:free`
+- Nvidia default model changed to `nvidia/nemotron-3-super-120b-a12b`
 ### Removed
 - GitHub provider
 ## [0.8] - 2026-06-14

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Each provider has a default model. You may optionally override it using either t
 | [**OpenRouter**](https://openrouter.ai/docs) | `OPENROUTER_API_KEY` | `z-ai/glm-5.2:free` | `OPENROUTER_MODEL` | ![](https://img.shields.io/github/actions/workflow/status/sepandhaghighi/mytext/api-openrouter.yml?style=flat-square&logo=openai&label=OpenRouter) |
 | [**Cerebras**](https://docs.cerebras.ai/) | `CEREBRAS_API_KEY` | `gpt-oss-120b` | `CEREBRAS_MODEL` | ![](https://img.shields.io/github/actions/workflow/status/sepandhaghighi/mytext/api-cerebras.yml?style=flat-square&logo=cerebras&label=Cerebras) |
 | [**Groq**](https://console.groq.com/docs) | `GROQ_API_KEY` | `openai/gpt-oss-20b` | `GROQ_MODEL` | ![](https://img.shields.io/github/actions/workflow/status/sepandhaghighi/mytext/api-groq.yml?style=flat-square&logo=groq&label=Groq) |
-| [**NVIDIA**](https://docs.nvidia.com/nim/) | `NVIDIA_API_KEY` | `meta/llama-3.1-8b-instruct` | `NVIDIA_MODEL` | ![](https://img.shields.io/github/actions/workflow/status/sepandhaghighi/mytext/api-nvidia.yml?style=flat-square&logo=nvidia&label=NVIDIA) |
+| [**NVIDIA**](https://docs.nvidia.com/nim/) | `NVIDIA_API_KEY` | `nvidia/nemotron-3-super-120b-a12b` | `NVIDIA_MODEL` | ![](https://img.shields.io/github/actions/workflow/status/sepandhaghighi/mytext/api-nvidia.yml?style=flat-square&logo=nvidia&label=NVIDIA) |
 
 
 ## Configuration Resolution Priority

--- a/mytext/params.py
+++ b/mytext/params.py
@@ -72,7 +72,7 @@ DEFAULT_MODELS = {
     Provider.OPENROUTER: "z-ai/glm-5.2:free",
     Provider.CEREBRAS: "gpt-oss-120b",
     Provider.GROQ: "openai/gpt-oss-20b",
-    Provider.NVIDIA: "meta/llama-3.1-8b-instruct",
+    Provider.NVIDIA: "nvidia/nemotron-3-super-120b-a12b",
 }
 
 PROVIDER_REQUIRED_KEYS = {


### PR DESCRIPTION
#### Reference Issues/PRs
#113 

#### What does this implement/fix? Explain your changes.
I searched for a few free models, with the most well-known ones being for Nvidia and OpenAI. The OpenAI models appeared a bit unstable, with one of them set to expire. Among the Nvidia models, I chose the one with the faster response time, as the quality was nearly identical.

#### Any other comments?

